### PR TITLE
restore previous selection if there weren't any matches

### DIFF
--- a/auto-percent.kak
+++ b/auto-percent.kak
@@ -15,7 +15,7 @@ define-command -hidden if-cursor -params 2 %{
         rmhooks window if-cursor
       }"
       # on absence of match
-      echo "hook -group if-cursor window RuntimeError 'nothing selected' %{ \
+      echo "hook -group if-cursor window RuntimeError 'nothing selected|no selections remaining' %{ \
         select '$kak_opt_previous_cursor'; \
         rmhooks window if-cursor
       }"

--- a/auto-percent.kak
+++ b/auto-percent.kak
@@ -14,6 +14,11 @@ define-command -hidden if-cursor -params 2 %{
         select '$kak_opt_previous_cursor'; \
         rmhooks window if-cursor
       }"
+      # on absence of match
+      echo "hook -group if-cursor window RuntimeError 'nothing selected' %{ \
+        select '$kak_opt_previous_cursor'; \
+        rmhooks window if-cursor
+      }"
       # on validated prompt
       echo "hook -group if-cursor window RawKey <ret> %{ \
         rmhooks window if-cursor


### PR DESCRIPTION
this also fixes an issue where the hooks would stay armed,
resulting in an unwanted jump on the next <ret> or <esc> press.