### PR TITLE
fix failing evecve when a lot of text is selected

### DIFF
--- a/auto-percent.kak
+++ b/auto-percent.kak
@@ -9,9 +9,9 @@ define-command -hidden if-cursor -params 2..3 %{
   set-option window last_auto_percent %arg{2}
 
   evaluate-commands %sh{
-    length=${#kak_selections}
-    if [ $length -eq 1 ]; then
-      if [ -z $3 ]; then
+    length="$kak_selections_length"
+    if [ "$length" -eq 1 ]; then
+      if [ -z "$3" ]; then
         # on cancelled prompt
         echo "hook -group if-cursor window RawKey <esc> %{ \
           select '$kak_selection_desc'; \


### PR DESCRIPTION
execve can fail if there is too much data passed by environment.

This commit fixes the issue by counting amount of selections without passing
selections content to the script.

The issue is visible when you open a big file and press (for example)
%<a-s>. This results in error:

    shell stderr: <<<
    execve failed: 7
    >>>

In strace we can see:

        [pid 18430] execve("/bin/sh", ["sh", "-c", "\n    
        length=\"${#kak_selections}\"\n    if [ \"$length\" -eq 1 ]; then\n
		...
        /* 61 vars */) = -1 E2BIG (Argument list too long)

User gets confusing feedback `saved 1 selection to register 'z'` in the
status line.